### PR TITLE
Amendments to testing the delete 

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -118,11 +118,11 @@ test("adding a second movie to the Binge list", () => {
     const deleteBtn = document.querySelectorAll('.delete');
     const movieDiv = document.querySelectorAll('.movie-name');
     const movietitle = document.querySelectorAll('.movie-title');
-    //if(this.item === undefined) {return}
-    deleteBtn[0].click(); //When the first delete button is clicked...
+    deleteBtn[0].click();
+    console.log(deleteBtn[0].parentElement === movieDiv[0])
     //const result = movieDiv[0].includes(movietitle[0])
-    const result = false;
-    const expected = false
+    const result = deleteBtn[0].parentElement;
+    const expected = 12;
     equal (result, expected);
   })
 

--- a/index-test.js
+++ b/index-test.js
@@ -41,7 +41,6 @@ setTimeout(() => { //Allows time for the elements to appear on the page as they'
   const result = title.classList.contains('strikethrough'); 
   const expected = false;
   equal(result, expected)
-  checkbox.click();
   });
 
   
@@ -127,7 +126,7 @@ setTimeout(() => { //Allows time for the elements to appear on the page as they'
     let deleteBtn = document.querySelectorAll('.delete');
     let movieDiv = document.querySelectorAll('.movie-name');
     let movietitle = document.querySelectorAll('.movie-title');
-    let parent = movieDiv[0].parentElement;
+    let parent = movieDiv[0].parentElement; //selecting to append back to page later
     let add = document.querySelector('#add-title')
 
     //create a replacent for after the test deletes the movie title
@@ -135,16 +134,16 @@ setTimeout(() => { //Allows time for the elements to appear on the page as they'
     let replacementTitle = movietitle[0]
     replacementTitle.classList.add('movie-title')
 
-    deleteBtn[0].click();
+    deleteBtn[0].click(); //click the delete button
     const result = deleteBtn[0].parentElement.childNodes[3].innerText === movietitle[0] //check that the p in the same div as the button has the correspondig movie title
     const expected = false;
     equal (result, expected);
 
-    replacementDiv.prepend(replacementTitle)
-    parent.insertBefore(replacementDiv, add.nextSibling)
+    //appended the item back to the page
+    replacementDiv.prepend(replacementTitle) //prepend makes it first child - this fixed positioning issue
+    parent.insertBefore(replacementDiv, add.nextSibling) //simular to above comment!
     
   })
-
 
   }, 13000);
 

--- a/index-test.js
+++ b/index-test.js
@@ -1,10 +1,8 @@
 // MINIMUM requirement of Unit Tests (as stated on project brief)
 
-//test("Submitting a new task adds it to the list", () => {
-// test goes here
-//});
+setTimeout(() => { //Allows time for the elements to appear on the page as they're not present onload.
 
-setTimeout(() => {
+  // CHECKBOX TESTING
 
   test("Checking first item marks it as complete", () => {
   const checkbox = document.querySelectorAll("input[type='checkbox']")
@@ -46,16 +44,8 @@ setTimeout(() => {
   checkbox.click();
   });
 
-  
-}, 6000);
+  // ADDING ITEM TESTING 
 
-//test("Deleting an entry removes it from the list", () => {
-// test goes here
-//});
-
-
-
-setTimeout(() => {
 
 test("adding a new movie title to the list", () => {
   
@@ -90,9 +80,6 @@ test("adding a new movie title to the list", () => {
   inputTitle.value = ``;
 })
 
-}, 5000);
-
-setTimeout(() => {
 
 test("adding a second movie to the Binge list", () => {
   //starting the new list from clicking the animated television
@@ -125,37 +112,7 @@ test("adding a second movie to the Binge list", () => {
   inputTitle.value = ``;
 })
 
-}, 5000);
-
-
-
-
-
-
-
-
-/*
-
-EXAMPLE: Integration test (to reference later) :)
-
-test("form submits expected result", () => {
-  const inputa = document.querySelector("#a");
-  inputa.value = 10;
-  const inputb = document.querySelector("#b");
-  inputb.value = 2;
-  const inputsign = document.querySelector("#sign");
-  inputsign.value = "*";
-  const submitButton = document.querySelector("button[type='submit']");
-  submitButton.click();
-  const result = document.querySelector("#result");
-  equal(result.textContent, "20");
-  result.textContent = "";
-});
-
-
-*/
-
-setTimeout(() => {
+// DELETE ITEM TESTING
 
   test("deleteItem() function should remove an item from the list", () => {
     const deleteBtn = document.querySelectorAll('button');
@@ -168,10 +125,8 @@ setTimeout(() => {
     equal (result, expected);
     deleteBtn[0].click();
   })
-  }, 5000);
-  
 
-setTimeout(() => { //Allows time for the elements to appear on the page as they're not present onload.
+  
 test("deleteItem() function should remove an item from the list", () => {
   const movieDiv = document.querySelectorAll('.movie-name') //Outer container
   const movieTitle = document.querySelectorAll('.movie-title') //Input value
@@ -182,7 +137,7 @@ test("deleteItem() function should remove an item from the list", () => {
   // const expected = false;
   equal (result, expected); //When result takes place, expected is what we should see.
   })
-  }, 5000);
 
-//Remove the delete button's class name. (Added in for test purposes)
+
+  }, 8000);
 

--- a/index-test.js
+++ b/index-test.js
@@ -44,8 +44,13 @@ setTimeout(() => { //Allows time for the elements to appear on the page as they'
   checkbox.click();
   });
 
+  
+  }, 8000);
+
+
   // ADDING ITEM TESTING 
 
+  setTimeout(() => { //Allows time for the elements to appear on the page as they're not present onload.
 
 test("adding a new movie title to the list", () => {
   
@@ -112,32 +117,34 @@ test("adding a second movie to the Binge list", () => {
   inputTitle.value = ``;
 })
 
+  }, 10100);
+
 // DELETE ITEM TESTING
 
-  test("deleteItem() function should remove an item from the list", () => {
-    const deleteBtn = document.querySelectorAll('.delete');
-    const movieDiv = document.querySelectorAll('.movie-name');
-    const movietitle = document.querySelectorAll('.movie-title');
+setTimeout(() => { //Allows time for the elements to appear on the page as they're not present onload.
+
+  test("deleteItem() function should remove the first item from the list", () => {
+    let deleteBtn = document.querySelectorAll('.delete');
+    let movieDiv = document.querySelectorAll('.movie-name');
+    let movietitle = document.querySelectorAll('.movie-title');
+    let parent = movieDiv[0].parentElement;
+    let add = document.querySelector('#add-title')
+
+    //create a replacent for after the test deletes the movie title
+    let replacementDiv =  movieDiv[0];
+    let replacementTitle = movietitle[0]
+    replacementTitle.classList.add('movie-title')
+
     deleteBtn[0].click();
-    console.log(deleteBtn[0].parentElement === movieDiv[0])
-    //const result = movieDiv[0].includes(movietitle[0])
-    const result = deleteBtn[0].parentElement;
-    const expected = 12;
+    const result = deleteBtn[0].parentElement.childNodes[3].innerText === movietitle[0] //check that the p in the same div as the button has the correspondig movie title
+    const expected = false;
     equal (result, expected);
-  })
 
-  
-test("deleteItem() function should remove an item from the list", () => {
-  const movieDiv = document.querySelectorAll('.movie-name') //Outer container
-  const movieTitle = document.querySelectorAll('.movie-title') //Input value
-  const deleteBtn = document.querySelectorAll('button') //delete button
-  if(this.item === undefined) {return} //This stops the .click() from returning an error message. 
-  let result = deleteBtn[0].click(); //When the first delete button is clicked...
-  const expected = deleteItem(movieDiv.contains(movieTitle[0]) == false); //...the first input will no longer be contained in the div.
-  // const expected = false;
-  equal (result, expected); //When result takes place, expected is what we should see.
+    replacementDiv.prepend(replacementTitle)
+    parent.insertBefore(replacementDiv, add.nextSibling)
+    
   })
 
 
-  }, 8000);
+  }, 13000);
 

--- a/index-test.js
+++ b/index-test.js
@@ -115,15 +115,15 @@ test("adding a second movie to the Binge list", () => {
 // DELETE ITEM TESTING
 
   test("deleteItem() function should remove an item from the list", () => {
-    const deleteBtn = document.querySelectorAll('button');
+    const deleteBtn = document.querySelectorAll('.delete');
     const movieDiv = document.querySelectorAll('.movie-name');
     const movietitle = document.querySelectorAll('.movie-title');
-    if(this.item === undefined) {return} //This stops the .click() from returning an error message. 
+    //if(this.item === undefined) {return}
     deleteBtn[0].click(); //When the first delete button is clicked...
-    const result = movieDiv.includes(movietitle[0])
+    //const result = movieDiv[0].includes(movietitle[0])
+    const result = false;
     const expected = false
     equal (result, expected);
-    deleteBtn[0].click();
   })
 
   

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ bingeWorthy.appendChild(doneButton);
 
 //create delete button
 const deleteButton = document.createElement('button');
+deleteButton.classList.add('delete')
 deleteButton.innerHTML = `<i class="fas fa-trash"></i>`;
 deleteButton.style.color = '#ed0014'
 deleteButton.style.borderColor = '#ed0014'
@@ -138,7 +139,6 @@ const editBtn = document.createElement('button');
 editBtn.innerHTML = editEmoji;
 editBtn.ariaLabel = "Edit";
 bingeWorthy.appendChild(editBtn);
-console.log(editBtn);
   
 
 //console.log(editBtn)
@@ -164,7 +164,6 @@ editBtn.addEventListener('click', () => {
 
   }
 })
-console.log(movieTitle);
   //append the edit button to control
   controls.appendChild(bingeWorthy, editBtn)
 

--- a/style.css
+++ b/style.css
@@ -206,6 +206,11 @@
     margin-left: 3px;
     
   }
+
+  .delete {
+    color: var(--venetian-red);
+    border-color: var(--venetian-red);
+  }
   
   /* List Headings */
   .listCategoryContainer {


### PR DESCRIPTION
Firstly - I put the add, check and delete tests in their own setTimeouts to avoid clashes. (There were some errors with the tests firing at the same time!)

Unfortunately even though `if(this.item === undefined) {return}` was getting rid of the errors it was returning before the `equal()` function had a chance to be called, which is why there was no 'PASS:' or 'FAIL:' in the console.

For the delete test:
- Originally when is was selecting with ` const deleteBtn = document.querySelectorAll('button');` it was actually picking up the first button on the page which was (i think) the '+' button. 
- I have added a class of `delete' to the delte buttons and changed the above point to 'let deleteBtn = document.querySelectorAll('.delete');'
- Now the test mimics the delete function by clicking the delete :) but - but this actually deletes the elements off the page!
- So that's why there are the 'replacement' variables to append back at the end of the test!
- The equal() func is checking if the clicked button has the corresponding movie title
- The result should be false (because we just deleted it!)
- At the end we are appending the items back in the right place. Took some working out I used these links to help: 

https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore
https://developer.mozilla.org/en-US/docs/Web/API/Element/prepend

Hope this makes sense. Please do ask q's!!!
